### PR TITLE
Simplify and modernize frontend layout

### DIFF
--- a/frontend/lobby.html
+++ b/frontend/lobby.html
@@ -8,11 +8,11 @@
   </head>
   <body data-page="lobby">
     <main id="app-shell" class="layout shell-page" aria-live="polite">
-      <header class="app-header surface-panel">
+      <header class="app-header shell-strip">
         <div class="app-brand">
           <p class="panel-eyebrow">Poker Bots Playground</p>
           <h1>Lobby</h1>
-          <p>Spin up new tables, scan the global leaderboard, and jump into live play from any device.</p>
+          <p>Create tables, scan the field, and get back into live play without wading through extra chrome.</p>
         </div>
         <nav class="app-nav" aria-label="Primary">
           <a id="nav-lobby" data-nav="lobby" href="/lobby">Lobby</a>
@@ -21,12 +21,12 @@
         </nav>
       </header>
 
-      <section class="page-intro surface-panel">
+      <section class="page-intro page-hero">
         <div>
           <p class="panel-eyebrow">Control Center</p>
-          <h2>Create tables and monitor field performance.</h2>
+          <h2>See what matters, then open the right table.</h2>
           <p class="page-intro-copy">
-            Responsive cards replace cramped mobile tables, while desktop keeps fast-scan metadata for frequent table switching.
+            Table creation stays close at hand, the leaderboard stays secondary, and the live table list remains easy to scan across screen sizes.
           </p>
         </div>
         <div class="page-intro-metrics">
@@ -37,7 +37,7 @@
       </section>
 
       <section class="lobby-grid">
-        <section class="lobby-panel surface-panel" aria-labelledby="create-table-title">
+        <section class="lobby-panel section-shell" aria-labelledby="create-table-title">
           <div class="panel-header">
             <div>
               <p class="panel-eyebrow">New Arena</p>
@@ -56,7 +56,7 @@
           <p id="create-table-feedback" class="lobby-feedback hidden" role="status"></p>
         </section>
 
-        <section class="lobby-panel surface-panel" aria-labelledby="lobby-leaderboard-title">
+        <section class="lobby-panel section-shell" aria-labelledby="lobby-leaderboard-title">
           <div class="panel-header">
             <div>
               <p class="panel-eyebrow">All-Time Form</p>
@@ -69,7 +69,7 @@
         </section>
       </section>
 
-      <section class="lobby-panel surface-panel" aria-labelledby="lobby-tables-title">
+      <section class="lobby-panel section-shell" aria-labelledby="lobby-tables-title">
         <div class="panel-header">
           <div>
             <p class="panel-eyebrow">Live Tables</p>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -9,32 +9,32 @@
   <body class="auth-screen">
     <main id="login-page" class="auth-layout" aria-live="polite">
       <section class="auth-grid">
-        <article class="auth-hero surface-panel" data-testid="auth-hero">
-          <p class="panel-eyebrow">Premium Poker Arena</p>
-          <h1>Run bot battles in a live, responsive poker lounge.</h1>
+        <article class="auth-hero" data-testid="auth-hero">
+          <p class="panel-eyebrow">Poker Bots Playground</p>
+          <h1>Run bot battles in a cleaner live control room.</h1>
           <p class="auth-subtitle">
-            Upload bots, manage multiple tables, track long-run results, and inspect every hand without losing the table view.
+            Create tables, seat bots, follow long-run performance, and inspect every hand without fighting through clutter.
           </p>
           <div class="auth-metrics">
-            <div class="metric-card">
+            <article class="metric-card">
               <span class="metric-value">6</span>
-              <span class="metric-label">Max seats per table</span>
-            </div>
-            <div class="metric-card">
+              <span class="metric-label">Seats per table</span>
+            </article>
+            <article class="metric-card">
               <span class="metric-value">Live</span>
-              <span class="metric-label">Polling match updates</span>
-            </div>
-            <div class="metric-card">
-              <span class="metric-value">History</span>
-              <span class="metric-label">Replay every hand</span>
-            </div>
+              <span class="metric-label">Match state stays in sync</span>
+            </article>
+            <article class="metric-card">
+              <span class="metric-value">Hands</span>
+              <span class="metric-label">Review full histories fast</span>
+            </article>
           </div>
         </article>
 
         <section class="auth-card surface-panel" data-testid="auth-card">
           <div class="auth-card-header">
             <p class="panel-eyebrow">Account Access</p>
-            <h2>Enter the arena</h2>
+            <h2>Sign in or create an account</h2>
             <p id="auth-subtitle" class="auth-subtitle">Sign in to access Lobby and My Bots.</p>
           </div>
 

--- a/frontend/my-bots.html
+++ b/frontend/my-bots.html
@@ -8,11 +8,11 @@
   </head>
   <body data-page="my-bots">
     <main id="app-shell" class="layout shell-page" aria-live="polite">
-      <header class="app-header surface-panel">
+      <header class="app-header shell-strip">
         <div class="app-brand">
           <p class="panel-eyebrow">Poker Bots Playground</p>
           <h1>My Bots</h1>
-          <p>Manage your private bot roster and keep new uploads ready for fast seating at any table.</p>
+          <p>Keep your private bot roster clean, readable, and ready to seat from anywhere in the app.</p>
         </div>
         <nav class="app-nav" aria-label="Primary">
           <a id="nav-lobby" data-nav="lobby" href="/lobby">Lobby</a>
@@ -21,12 +21,12 @@
         </nav>
       </header>
 
-      <section class="page-intro surface-panel">
+      <section class="page-intro page-hero">
         <div>
           <p class="panel-eyebrow">Bot Catalog</p>
           <h2>Upload once, seat anywhere.</h2>
           <p class="page-intro-copy">
-            The upload flow keeps metadata readable, states explicit, and the catalog easy to scan across desktop and mobile.
+            The upload flow stays close to the catalog, statuses stay readable, and the page avoids the oversized empty panels that slow down quick management.
           </p>
         </div>
         <div class="page-intro-metrics">
@@ -37,7 +37,7 @@
       </section>
 
       <section class="my-bots-grid">
-        <section class="my-bots-panel surface-panel" aria-labelledby="my-bots-upload-title">
+        <section class="my-bots-panel section-shell" aria-labelledby="my-bots-upload-title">
           <div class="panel-header">
             <div>
               <p class="panel-eyebrow">Upload</p>
@@ -59,7 +59,7 @@
           <p id="my-bots-upload-feedback" class="my-bots-upload-feedback hidden" role="status"></p>
         </section>
 
-        <section class="my-bots-panel surface-panel" aria-labelledby="my-bots-catalog-title">
+        <section class="my-bots-panel section-shell" aria-labelledby="my-bots-catalog-title">
           <div class="panel-header">
             <div>
               <p class="panel-eyebrow">Catalog</p>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,46 +1,46 @@
 :root {
   color-scheme: light;
-  --bg: #f5efe4;
-  --bg-strong: #efe4d0;
-  --surface: rgba(255, 251, 244, 0.88);
-  --surface-strong: rgba(255, 250, 241, 0.96);
-  --surface-muted: rgba(249, 240, 225, 0.9);
-  --border: rgba(92, 72, 40, 0.16);
-  --border-strong: rgba(67, 49, 23, 0.3);
-  --text: #20180f;
-  --muted: #645646;
-  --muted-strong: #4d4032;
-  --accent: #19624c;
-  --accent-strong: #114a38;
-  --accent-soft: rgba(25, 98, 76, 0.12);
-  --gold: #b78d3d;
-  --gold-soft: rgba(183, 141, 61, 0.15);
-  --danger: #af4738;
-  --warning: #9a6a20;
-  --info: #355f8c;
-  --shadow-soft: 0 18px 50px rgba(46, 31, 13, 0.09);
-  --shadow-strong: 0 24px 80px rgba(28, 17, 4, 0.18);
-  --radius-sm: 10px;
-  --radius-md: 18px;
-  --radius-lg: 28px;
+  --bg: #f7f2e8;
+  --bg-strong: #efe6d7;
+  --surface: rgba(255, 252, 247, 0.74);
+  --surface-strong: rgba(255, 251, 244, 0.9);
+  --surface-muted: rgba(244, 237, 226, 0.88);
+  --surface-contrast: rgba(20, 39, 31, 0.9);
+  --card-border: rgba(69, 52, 24, 0.12);
+  --card-border-strong: rgba(69, 52, 24, 0.2);
+  --line: rgba(69, 52, 24, 0.12);
+  --line-strong: rgba(69, 52, 24, 0.18);
+  --text: #1f180e;
+  --muted: #695b48;
+  --muted-strong: #4f412f;
+  --accent: #1f6d55;
+  --accent-strong: #154838;
+  --accent-soft: rgba(31, 109, 85, 0.12);
+  --accent-soft-strong: rgba(31, 109, 85, 0.18);
+  --blue: #295877;
+  --blue-soft: rgba(41, 88, 119, 0.12);
+  --gold: #b38433;
+  --gold-soft: rgba(179, 132, 51, 0.16);
+  --danger: #b34b3d;
+  --danger-soft: rgba(179, 75, 61, 0.12);
+  --warning: #9a6d28;
+  --warning-soft: rgba(154, 109, 40, 0.12);
+  --shadow-soft: 0 18px 40px rgba(34, 24, 11, 0.08);
+  --shadow-strong: 0 28px 72px rgba(28, 18, 6, 0.14);
+  --radius-sm: 14px;
+  --radius-md: 22px;
+  --radius-lg: 32px;
   --radius-pill: 999px;
-  --space-1: 0.35rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
-  --space-7: 3rem;
   --font-sans: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
   --font-display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
   --transition-fast: 160ms ease;
-  --transition-base: 220ms ease;
+  --transition-base: 240ms ease;
 }
 
 @keyframes page-enter {
   from {
     opacity: 0;
-    transform: translateY(16px);
+    transform: translateY(14px);
   }
 
   to {
@@ -52,19 +52,19 @@
 @keyframes card-enter {
   from {
     opacity: 0;
-    transform: translateY(12px) scale(0.98);
+    transform: translateY(10px);
   }
 
   to {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translateY(0);
   }
 }
 
 @keyframes toast-enter {
   from {
     opacity: 0;
-    transform: translateY(-10px) scale(0.98);
+    transform: translateY(-8px) scale(0.98);
   }
 
   to {
@@ -76,11 +76,15 @@
 @keyframes pulse-glow {
   0%,
   100% {
-    box-shadow: 0 0 0 rgba(183, 141, 61, 0);
+    box-shadow:
+      inset 0 0 70px rgba(0, 0, 0, 0.24),
+      0 24px 64px rgba(17, 11, 4, 0.22);
   }
 
   50% {
-    box-shadow: 0 0 28px rgba(183, 141, 61, 0.2);
+    box-shadow:
+      inset 0 0 84px rgba(0, 0, 0, 0.22),
+      0 28px 72px rgba(17, 11, 4, 0.26);
   }
 }
 
@@ -98,32 +102,36 @@ body {
   color: var(--text);
   font-family: var(--font-sans);
   background:
-    radial-gradient(circle at top left, rgba(255, 244, 215, 0.9), transparent 35%),
-    radial-gradient(circle at top right, rgba(32, 95, 70, 0.15), transparent 32%),
-    linear-gradient(180deg, #f7f1e4 0%, #f4ead9 42%, #ecddc3 100%);
+    radial-gradient(circle at top left, rgba(31, 109, 85, 0.11), transparent 30%),
+    radial-gradient(circle at 88% 0%, rgba(179, 132, 51, 0.13), transparent 24%),
+    linear-gradient(180deg, #faf7f0 0%, #f5eedf 52%, #efe6d7 100%);
 }
 
 body::before {
   content: "";
   position: fixed;
   inset: 0;
+  z-index: 0;
   pointer-events: none;
+  opacity: 0.55;
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.28), transparent 45%),
-    repeating-linear-gradient(
-      135deg,
-      rgba(110, 82, 46, 0.015) 0,
-      rgba(110, 82, 46, 0.015) 2px,
-      transparent 2px,
-      transparent 12px
-    );
+    linear-gradient(180deg, rgba(255, 255, 255, 0.45), transparent 32%),
+    linear-gradient(90deg, rgba(30, 67, 52, 0.035) 1px, transparent 1px),
+    linear-gradient(0deg, rgba(30, 67, 52, 0.028) 1px, transparent 1px);
+  background-size:
+    auto,
+    42px 42px,
+    42px 42px;
 }
 
 h1,
 h2,
 h3,
 h4,
-p {
+p,
+ul,
+ol,
+pre {
   margin: 0;
 }
 
@@ -132,7 +140,7 @@ h2,
 h3,
 h4 {
   font-family: var(--font-display);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.025em;
 }
 
 a,
@@ -151,22 +159,23 @@ button {
   appearance: none;
   border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  padding: 0.8rem 1.1rem;
+  padding: 0.85rem 1.15rem;
   font-weight: 700;
-  color: #fff9f0;
+  color: #fffaf3;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 10px 24px rgba(17, 74, 56, 0.18);
+  box-shadow: 0 14px 28px rgba(21, 72, 56, 0.16);
   cursor: pointer;
   transition:
     transform var(--transition-fast),
-    filter var(--transition-fast),
     box-shadow var(--transition-fast),
-    background var(--transition-fast);
+    filter var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 button:hover:not(:disabled) {
   transform: translateY(-1px);
-  filter: brightness(1.03);
+  filter: brightness(1.02);
 }
 
 button:disabled {
@@ -180,7 +189,7 @@ a:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-  outline: 3px solid rgba(25, 98, 76, 0.22);
+  outline: 3px solid rgba(31, 109, 85, 0.18);
   outline-offset: 2px;
 }
 
@@ -188,11 +197,11 @@ input,
 select,
 textarea {
   width: 100%;
-  border: 1px solid var(--border);
-  border-radius: 14px;
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
   padding: 0.82rem 0.95rem;
   color: var(--text);
-  background: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.92);
   transition:
     border-color var(--transition-fast),
     box-shadow var(--transition-fast),
@@ -202,14 +211,14 @@ textarea {
 input:hover,
 select:hover,
 textarea:hover {
-  border-color: rgba(92, 72, 40, 0.28);
+  border-color: var(--card-border-strong);
 }
 
 input:focus,
 select:focus,
 textarea:focus {
-  border-color: rgba(25, 98, 76, 0.42);
-  box-shadow: 0 0 0 4px rgba(25, 98, 76, 0.1);
+  border-color: rgba(31, 109, 85, 0.3);
+  box-shadow: 0 0 0 4px rgba(31, 109, 85, 0.08);
 }
 
 .hidden {
@@ -217,31 +226,25 @@ textarea:focus {
 }
 
 .surface-panel,
-.history-panel,
-.lobby-panel,
-.my-bots-panel,
 .auth-card,
-.auth-hero {
+.seat-assignment {
   position: relative;
   overflow: hidden;
   background: linear-gradient(180deg, var(--surface-strong), var(--surface));
-  border: 1px solid var(--border);
+  border: 1px solid var(--card-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(16px);
+  backdrop-filter: blur(14px);
 }
 
 .surface-panel::after,
-.history-panel::after,
-.lobby-panel::after,
-.my-bots-panel::after,
 .auth-card::after,
-.auth-hero::after {
+.seat-assignment::after {
   content: "";
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.25), transparent 24%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.28), transparent 24%);
 }
 
 .panel-eyebrow {
@@ -259,8 +262,8 @@ textarea:focus {
 }
 
 .input-error {
-  border-color: rgba(175, 71, 56, 0.55) !important;
-  box-shadow: 0 0 0 4px rgba(175, 71, 56, 0.1);
+  border-color: rgba(179, 75, 61, 0.45) !important;
+  box-shadow: 0 0 0 4px rgba(179, 75, 61, 0.08) !important;
 }
 
 .field-error,
@@ -297,19 +300,19 @@ textarea:focus {
 }
 
 .button-secondary {
-  background: linear-gradient(135deg, #2f5a6d, #204254);
-  box-shadow: 0 10px 24px rgba(32, 66, 84, 0.16);
+  background: linear-gradient(135deg, #335d7a, #214256);
+  box-shadow: 0 14px 28px rgba(33, 66, 86, 0.15);
 }
 
 .button-danger {
-  background: linear-gradient(135deg, #bf5848, #913326);
-  box-shadow: 0 10px 24px rgba(145, 51, 38, 0.18);
+  background: linear-gradient(135deg, #c25a49, #943326);
+  box-shadow: 0 14px 28px rgba(148, 51, 38, 0.15);
 }
 
 .button-ghost {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.45);
-  border-color: rgba(92, 72, 40, 0.16);
+  background: rgba(255, 255, 255, 0.8);
+  border-color: var(--card-border);
   box-shadow: none;
 }
 
@@ -320,46 +323,50 @@ textarea:focus {
 .layout {
   position: relative;
   z-index: 1;
-  width: min(1400px, 100%);
+  width: min(1680px, calc(100vw - clamp(1rem, 3vw, 3rem)));
   margin: 0 auto;
-  padding: var(--space-5);
+  padding: clamp(1rem, 2.6vw, 2.2rem) 0;
   display: grid;
-  gap: var(--space-4);
-  animation: page-enter 420ms cubic-bezier(0.21, 1, 0.32, 1);
+  gap: clamp(1.2rem, 2vw, 2rem);
+  animation: page-enter 380ms cubic-bezier(0.21, 1, 0.32, 1);
 }
 
 .shell-page {
-  padding-bottom: var(--space-7);
+  padding-bottom: clamp(2rem, 5vw, 4rem);
 }
 
-.app-header {
-  padding: 1.15rem 1.35rem;
+.shell-strip {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-4);
+  gap: 1rem 1.5rem;
   flex-wrap: wrap;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--line-strong);
 }
 
 .app-brand {
   display: grid;
-  gap: 0.35rem;
-  max-width: 700px;
+  gap: 0.4rem;
+  max-width: 60rem;
 }
 
 .app-brand h1 {
-  font-size: clamp(1.9rem, 4vw, 2.8rem);
+  font-size: clamp(2.2rem, 5vw, 4.2rem);
+  line-height: 0.92;
 }
 
 .app-brand p:last-child {
+  max-width: 52ch;
   color: var(--muted);
-  max-width: 60ch;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 .app-nav {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.7rem;
   flex-wrap: wrap;
 }
 
@@ -374,12 +381,13 @@ textarea:focus {
   border-radius: var(--radius-pill);
   font-weight: 700;
   color: var(--text);
-  background: rgba(255, 255, 255, 0.55);
-  border: 1px solid rgba(92, 72, 40, 0.14);
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid var(--card-border);
   transition:
     transform var(--transition-fast),
     background var(--transition-fast),
-    border-color var(--transition-fast);
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .app-nav a:hover {
@@ -387,28 +395,37 @@ textarea:focus {
 }
 
 .app-nav a.active {
-  background: linear-gradient(135deg, rgba(25, 98, 76, 0.18), rgba(17, 74, 56, 0.08));
-  border-color: rgba(25, 98, 76, 0.28);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border-color: transparent;
+  color: #fffaf3;
+  box-shadow: 0 12px 24px rgba(21, 72, 56, 0.14);
 }
 
-.page-intro {
-  padding: 1.3rem 1.35rem;
+.page-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.95fr);
-  gap: var(--space-4);
-  align-items: center;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.85fr);
+  gap: 1rem 1.5rem;
+  align-items: start;
+  padding-bottom: 1.35rem;
+  border-bottom: 1px solid var(--line);
 }
 
 .page-intro h2 {
-  font-size: clamp(1.4rem, 2vw, 2rem);
+  font-size: clamp(1.7rem, 2.8vw, 2.6rem);
+  line-height: 0.98;
   margin-top: 0.25rem;
   margin-bottom: 0.45rem;
+}
+
+.page-intro-copy {
+  max-width: 62ch;
+  line-height: 1.55;
 }
 
 .page-intro-metrics {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.7rem;
   justify-content: flex-end;
 }
 
@@ -420,11 +437,11 @@ textarea:focus {
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
-  min-height: 38px;
-  padding: 0.5rem 0.85rem;
+  min-height: 40px;
+  padding: 0.52rem 0.9rem;
   border-radius: var(--radius-pill);
-  border: 1px solid rgba(92, 72, 40, 0.13);
-  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--card-border);
+  background: rgba(255, 255, 255, 0.76);
   color: var(--muted-strong);
   font-size: 0.88rem;
   font-weight: 700;
@@ -434,39 +451,69 @@ textarea:focus {
   color: var(--text);
 }
 
+.auth-user {
+  color: var(--muted-strong);
+}
+
 .metric-pill-status,
 .table-state-pill[data-state="running"],
 .seat[data-state="ready"] .seat-status {
-  background: rgba(25, 98, 76, 0.12);
-  border-color: rgba(25, 98, 76, 0.26);
+  background: rgba(31, 109, 85, 0.1);
+  border-color: rgba(31, 109, 85, 0.2);
   color: var(--accent-strong);
 }
 
 .metric-pill-status[data-state="paused"],
 .table-state-pill[data-state="paused"] {
-  background: rgba(154, 106, 32, 0.12);
-  border-color: rgba(154, 106, 32, 0.24);
+  background: var(--warning-soft);
+  border-color: rgba(154, 109, 40, 0.18);
   color: var(--warning);
 }
 
 .metric-pill-status[data-state="stopped"],
 .table-state-pill[data-state="stopped"],
 .table-state-pill[data-state="waiting"] {
-  background: rgba(53, 95, 140, 0.08);
-  border-color: rgba(53, 95, 140, 0.18);
-  color: var(--info);
+  background: var(--blue-soft);
+  border-color: rgba(41, 88, 119, 0.18);
+  color: var(--blue);
 }
 
 .metric-pill-status[data-state="ended"],
 .table-state-pill[data-state="ended"] {
-  background: rgba(175, 71, 56, 0.1);
-  border-color: rgba(175, 71, 56, 0.18);
+  background: var(--danger-soft);
+  border-color: rgba(179, 75, 61, 0.18);
   color: var(--danger);
 }
 
-.auth-user {
-  font-weight: 700;
-  color: var(--muted-strong);
+.section-shell {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding-top: 1.15rem;
+  border-top: 1px solid var(--line);
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem 1rem;
+  flex-wrap: wrap;
+}
+
+.panel-header-tight {
+  margin-bottom: -0.15rem;
+}
+
+.panel-header h2 {
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+  line-height: 1;
+  margin-top: 0.2rem;
+}
+
+.panel-body {
+  display: grid;
+  gap: 1rem;
 }
 
 .auth-screen {
@@ -474,71 +521,83 @@ textarea:focus {
 }
 
 .auth-layout {
+  position: relative;
+  z-index: 1;
   min-height: 100vh;
-  padding: var(--space-5);
+  width: min(1480px, calc(100vw - clamp(1rem, 4vw, 4rem)));
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 2.4rem) 0;
   display: grid;
   place-items: center;
 }
 
 .auth-grid {
-  width: min(1160px, 100%);
+  width: 100%;
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(360px, 0.85fr);
-  gap: var(--space-4);
+  grid-template-columns: minmax(0, 1.15fr) minmax(360px, 0.82fr);
+  gap: clamp(1rem, 2vw, 1.8rem);
   align-items: stretch;
 }
 
-.auth-hero,
-.auth-card {
-  padding: clamp(1.4rem, 3vw, 2rem);
-  animation: card-enter 460ms cubic-bezier(0.21, 1, 0.32, 1);
-}
-
 .auth-hero {
-  display: grid;
-  gap: var(--space-4);
+  position: relative;
+  overflow: hidden;
+  padding: clamp(1.75rem, 4vw, 3rem);
+  border-radius: 40px;
+  border: 1px solid rgba(69, 52, 24, 0.12);
   background:
-    radial-gradient(circle at top right, rgba(183, 141, 61, 0.18), transparent 35%),
-    radial-gradient(circle at bottom left, rgba(25, 98, 76, 0.14), transparent 28%),
-    linear-gradient(135deg, rgba(255, 251, 244, 0.97), rgba(249, 238, 220, 0.92));
+    radial-gradient(circle at top right, rgba(179, 132, 51, 0.16), transparent 28%),
+    radial-gradient(circle at bottom left, rgba(31, 109, 85, 0.13), transparent 34%),
+    linear-gradient(145deg, rgba(255, 252, 247, 0.84), rgba(248, 241, 231, 0.72));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.42);
+  display: grid;
+  gap: 1.6rem;
+  align-content: space-between;
 }
 
 .auth-hero h1 {
-  font-size: clamp(2.2rem, 5vw, 4rem);
-  max-width: 11ch;
-  line-height: 0.97;
+  max-width: 8ch;
+  font-size: clamp(3rem, 7vw, 5.8rem);
+  line-height: 0.86;
+}
+
+.auth-hero .auth-subtitle {
+  max-width: 44rem;
+  font-size: 1.02rem;
+  line-height: 1.55;
 }
 
 .auth-metrics {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-3);
+  gap: 1rem;
 }
 
 .metric-card {
-  padding: 1rem;
-  border-radius: 20px;
-  border: 1px solid rgba(92, 72, 40, 0.12);
-  background: rgba(255, 255, 255, 0.5);
   display: grid;
-  gap: 0.25rem;
+  gap: 0.28rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line-strong);
 }
 
 .metric-value {
   font-family: var(--font-display);
-  font-size: 1.5rem;
+  font-size: 1.7rem;
   font-weight: 700;
   color: var(--accent-strong);
 }
 
 .metric-label {
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.92rem;
+  line-height: 1.45;
 }
 
 .auth-card {
+  padding: clamp(1.5rem, 3vw, 2.1rem);
   display: grid;
   gap: 1rem;
+  align-content: start;
 }
 
 .auth-card-header {
@@ -547,31 +606,32 @@ textarea:focus {
 }
 
 .auth-card-header h2 {
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  line-height: 0.95;
 }
 
 .auth-mode-switch {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
+  gap: 0.65rem;
 }
 
 .auth-mode-button {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.55);
-  border-color: rgba(92, 72, 40, 0.13);
+  background: rgba(255, 255, 255, 0.82);
+  border-color: var(--card-border);
   box-shadow: none;
 }
 
 .auth-mode-button.active {
-  color: #fff9f0;
+  color: #fffaf3;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 10px 24px rgba(17, 74, 56, 0.18);
+  box-shadow: 0 14px 28px rgba(21, 72, 56, 0.16);
 }
 
 .auth-form {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.55rem;
 }
 
 .form-error,
@@ -584,16 +644,34 @@ textarea:focus {
   font-size: 0.92rem;
 }
 
+.lobby-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.78fr) minmax(0, 1.22fr);
+  gap: clamp(1rem, 2vw, 1.6rem);
+}
+
+.my-bots-grid {
+  display: grid;
+  grid-template-columns: minmax(340px, 0.78fr) minmax(0, 1.22fr);
+  gap: clamp(1rem, 2vw, 1.6rem);
+}
+
 .arena-layout {
   display: grid;
-  gap: var(--space-4);
-  grid-template-columns: minmax(0, 1.2fr) minmax(360px, 0.8fr);
+  grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.85fr);
+  gap: clamp(1rem, 2vw, 1.8rem);
   align-items: start;
 }
 
 .arena-stage {
   display: grid;
-  gap: var(--space-4);
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.history-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: clamp(1rem, 2vw, 1.6rem);
 }
 
 .table-area,
@@ -602,57 +680,240 @@ textarea:focus {
 .history-panel,
 .my-bots-panel,
 .lobby-panel {
-  padding: 1.2rem;
-  display: grid;
-  gap: 1rem;
+  background: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  overflow: visible;
 }
 
-.panel-header {
+.table-area::after,
+.match-controls::after,
+.pnl-panel::after,
+.history-panel::after,
+.my-bots-panel::after,
+.lobby-panel::after {
+  display: none;
+}
+
+.create-table-form,
+.my-bots-upload-form,
+.match-status-card,
+.pnl-chart,
+.hand-detail,
+.seat-assignment-form,
+.lobby-table-card,
+.my-bot-card,
+.lobby-leaderboard-item,
+.leaderboard-item,
+.hands-list button {
+  background: linear-gradient(180deg, rgba(255, 253, 248, 0.86), rgba(248, 241, 232, 0.84));
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  box-shadow: var(--shadow-soft);
+}
+
+.create-table-form,
+.my-bots-upload-form {
+  display: grid;
+  gap: 0.6rem 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 1.1rem;
+}
+
+#create-table-submit,
+#my-bots-upload-submit,
+.my-bots-upload-form #bot-file {
+  grid-column: 1 / -1;
+}
+
+.lobby-state,
+.my-bots-state {
+  padding: 0.35rem 0;
+}
+
+.lobby-table-scroll {
+  overflow-x: auto;
+  border-radius: 24px;
+  border: 1px solid var(--card-border);
+  background: rgba(255, 252, 247, 0.76);
+  box-shadow: var(--shadow-soft);
+}
+
+.lobby-tables-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 680px;
+}
+
+.lobby-tables-table th,
+.lobby-tables-table td {
+  padding: 1rem 0.85rem;
+  border-bottom: 1px solid rgba(69, 52, 24, 0.08);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.lobby-tables-table tr:last-child td {
+  border-bottom: none;
+}
+
+.lobby-tables-table th {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.table-id {
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.82rem;
+}
+
+.lobby-table-cards {
+  display: none;
+  gap: 0.9rem;
+}
+
+.lobby-table-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  animation: card-enter 260ms ease;
+}
+
+.lobby-table-card-header,
+.my-bot-card-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-3);
+  gap: 0.75rem;
+}
+
+.lobby-card-meta,
+.my-bot-meta-row,
+.lobby-leaderboard-meta {
+  color: var(--muted);
+}
+
+.lobby-card-stats {
+  display: flex;
   flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+  color: var(--muted-strong);
+  font-weight: 700;
 }
 
-.panel-header-tight {
-  margin-bottom: -0.15rem;
+.lobby-leaderboard-list,
+.my-bots-list,
+.leaderboard-list,
+.hands-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.panel-body {
+.lobby-leaderboard-list,
+.leaderboard-list {
   display: grid;
+  gap: 0.8rem;
+}
+
+.lobby-leaderboard-item {
+  padding: 1rem 1.05rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.85rem;
+  animation: card-enter 260ms ease;
+}
+
+.lobby-leaderboard-rank {
+  font-weight: 800;
+}
+
+.lobby-leaderboard-stat {
+  color: var(--accent);
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.my-bots-list {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.my-bot-card {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem 1.05rem;
+  animation: card-enter 260ms ease;
+}
+
+.my-bot-card h3 {
+  font-size: 1.2rem;
+}
+
+.my-bot-meta-row {
+  display: grid;
+  gap: 0.15rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid rgba(69, 52, 24, 0.08);
+  font-size: 0.95rem;
+}
+
+.my-bot-meta-row strong {
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.my-bot-meta-row span {
+  color: var(--muted-strong);
+  font-weight: 600;
+}
+
+.bot-status-pill {
+  background: rgba(31, 109, 85, 0.11);
+  border-color: rgba(31, 109, 85, 0.16);
+  color: var(--accent-strong);
 }
 
 .poker-table {
   position: relative;
-  min-height: 560px;
-  aspect-ratio: 1.1 / 0.88;
-  border-radius: 42%;
-  border: 8px solid rgba(187, 145, 72, 0.82);
+  min-height: 620px;
+  aspect-ratio: 1.18 / 0.82;
+  border-radius: 999px;
+  border: 10px solid rgba(187, 145, 72, 0.82);
   background:
-    radial-gradient(circle at center, rgba(47, 125, 90, 0.96) 0%, rgba(23, 89, 67, 0.98) 58%, rgba(15, 55, 42, 1) 100%);
+    radial-gradient(circle at center, rgba(49, 126, 92, 0.97) 0%, rgba(22, 86, 64, 0.99) 58%, rgba(14, 52, 39, 1) 100%);
   box-shadow:
-    inset 0 0 80px rgba(0, 0, 0, 0.28),
-    0 30px 70px rgba(23, 16, 4, 0.24);
+    inset 0 0 72px rgba(0, 0, 0, 0.24),
+    0 28px 72px rgba(22, 15, 6, 0.2);
   overflow: hidden;
+  animation: pulse-glow 4s ease-in-out infinite;
 }
 
 .poker-table::before {
   content: "";
   position: absolute;
-  inset: 4.5%;
-  border-radius: 42%;
-  border: 1px solid rgba(241, 223, 180, 0.25);
+  inset: 4.75%;
+  border-radius: 999px;
+  border: 1px solid rgba(241, 223, 180, 0.24);
   pointer-events: none;
 }
 
 .poker-table::after {
   content: "";
   position: absolute;
-  inset: auto 10% 12%;
-  height: 18%;
+  inset: auto 12% 11%;
+  height: 20%;
   border-radius: 999px;
-  background: radial-gradient(circle at center, rgba(255, 244, 214, 0.14), transparent 70%);
+  background: radial-gradient(circle at center, rgba(255, 244, 214, 0.12), transparent 70%);
   pointer-events: none;
 }
 
@@ -662,26 +923,25 @@ textarea:focus {
   transform: translate(-50%, -50%);
   width: min(280px, 52%);
   padding: 1rem 1.1rem;
-  border-radius: 28px;
-  background: rgba(12, 33, 25, 0.68);
-  border: 1px solid rgba(241, 223, 180, 0.16);
-  color: #f5ead2;
+  border-radius: 30px;
+  background: rgba(15, 36, 28, 0.72);
+  border: 1px solid rgba(241, 223, 180, 0.14);
+  color: #f8ecd6;
   text-align: center;
   display: grid;
-  gap: 0.4rem;
-  animation: pulse-glow 3.6s ease-in-out infinite;
+  gap: 0.42rem;
 }
 
 .table-center-eyebrow {
-  color: rgba(255, 235, 185, 0.8);
-  font-size: 0.76rem;
-  font-weight: 700;
+  color: rgba(255, 235, 185, 0.82);
+  font-size: 0.74rem;
+  font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .table-center-title {
-  font-size: clamp(1.4rem, 2.6vw, 2.1rem);
+  font-size: clamp(1.55rem, 2.8vw, 2.2rem);
 }
 
 .table-center-meta {
@@ -690,42 +950,44 @@ textarea:focus {
   justify-content: center;
   gap: 0.8rem;
   flex-wrap: wrap;
-  font-size: 0.9rem;
-  color: rgba(245, 234, 210, 0.86);
+  font-size: 0.92rem;
+  color: rgba(248, 236, 214, 0.88);
 }
 
 .seat {
   position: absolute;
-  width: min(170px, 30%);
+  width: min(176px, 30%);
   transform-origin: center;
-  transition: transform var(--transition-base), filter var(--transition-base);
+  transition:
+    transform var(--transition-base),
+    filter var(--transition-base);
 }
 
 .seat:hover {
-  filter: drop-shadow(0 18px 24px rgba(0, 0, 0, 0.14));
+  filter: drop-shadow(0 16px 24px rgba(0, 0, 0, 0.14));
 }
 
 .seat-shell {
-  padding: 0.85rem;
-  border-radius: 22px;
-  border: 1px solid rgba(92, 72, 40, 0.14);
-  background: rgba(255, 250, 242, 0.96);
-  box-shadow: 0 18px 40px rgba(18, 10, 3, 0.2);
+  padding: 0.9rem;
+  border-radius: 24px;
+  border: 1px solid rgba(69, 52, 24, 0.12);
+  background: rgba(255, 251, 245, 0.96);
+  box-shadow: 0 14px 30px rgba(19, 11, 4, 0.18);
   display: grid;
   gap: 0.65rem;
   text-align: left;
 }
 
 .seat[data-state="ready"] .seat-shell {
-  border-color: rgba(25, 98, 76, 0.24);
-  background: linear-gradient(180deg, rgba(245, 255, 251, 0.96), rgba(239, 250, 246, 0.94));
+  background: linear-gradient(180deg, rgba(245, 255, 251, 0.96), rgba(236, 249, 244, 0.94));
+  border-color: rgba(31, 109, 85, 0.2);
 }
 
 .seat-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.55rem;
 }
 
 .seat-head h3 {
@@ -751,12 +1013,12 @@ textarea:focus {
 
 .seat-2 {
   top: 18%;
-  right: 2.3rem;
+  right: 2.5rem;
 }
 
 .seat-3 {
   bottom: 20%;
-  right: 2.3rem;
+  right: 2.5rem;
 }
 
 .seat-4 {
@@ -767,12 +1029,12 @@ textarea:focus {
 
 .seat-5 {
   bottom: 20%;
-  left: 2.3rem;
+  left: 2.5rem;
 }
 
 .seat-6 {
   top: 18%;
-  left: 2.3rem;
+  left: 2.5rem;
 }
 
 .match-buttons {
@@ -781,11 +1043,12 @@ textarea:focus {
   gap: 0.75rem;
 }
 
+.match-buttons > * {
+  flex: 1 1 8.75rem;
+}
+
 .match-status-card {
-  padding: 1rem;
-  border-radius: 20px;
-  border: 1px solid rgba(92, 72, 40, 0.12);
-  background: rgba(255, 255, 255, 0.52);
+  padding: 1rem 1.1rem;
   display: grid;
   gap: 0.35rem;
 }
@@ -794,24 +1057,19 @@ textarea:focus {
   font-weight: 700;
 }
 
+.pnl-panel {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+}
+
 .pnl-subtitle {
   font-size: 0.95rem;
   color: var(--muted);
 }
 
-.leaderboard-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.65rem;
-}
-
 .leaderboard-item {
-  padding: 0.8rem 0.9rem;
-  border-radius: 18px;
-  border: 1px solid rgba(92, 72, 40, 0.12);
-  background: rgba(255, 255, 255, 0.55);
+  padding: 0.85rem 0.95rem;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.8rem;
@@ -849,15 +1107,15 @@ textarea:focus {
 }
 
 .leaderboard-dot-3 {
-  background: #9257d6;
+  background: #bf6b21;
 }
 
 .leaderboard-dot-4 {
-  background: #d46d1f;
+  background: #7c59c8;
 }
 
 .leaderboard-dot-5 {
-  background: #1189b6;
+  background: #1684a6;
 }
 
 .leaderboard-dot-6 {
@@ -879,13 +1137,12 @@ textarea:focus {
 
 .pnl-chart {
   position: relative;
-  min-height: 320px;
-  border-radius: 24px;
-  border: 1px solid rgba(92, 72, 40, 0.12);
-  background:
-    linear-gradient(180deg, rgba(25, 98, 76, 0.12), rgba(255, 255, 255, 0.3)),
-    rgba(255, 255, 255, 0.45);
+  min-height: 340px;
+  padding: 0.25rem;
   overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(31, 109, 85, 0.08), rgba(255, 255, 255, 0.5)),
+    rgba(255, 255, 255, 0.54);
 }
 
 .pnl-chart svg {
@@ -915,15 +1172,15 @@ textarea:focus {
 }
 
 .pnl-line-3 {
-  stroke: #9257d6;
+  stroke: #bf6b21;
 }
 
 .pnl-line-4 {
-  stroke: #d46d1f;
+  stroke: #7c59c8;
 }
 
 .pnl-line-5 {
-  stroke: #1189b6;
+  stroke: #1684a6;
 }
 
 .pnl-line-6 {
@@ -940,21 +1197,16 @@ textarea:focus {
   background: linear-gradient(180deg, transparent, rgba(248, 243, 232, 0.96));
 }
 
-.history-grid {
-  display: grid;
-  gap: var(--space-4);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
 .hands-body {
-  gap: 0.85rem;
+  display: grid;
+  gap: 0.9rem;
 }
 
 .hands-controls {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-3);
+  gap: 0.8rem;
   flex-wrap: wrap;
 }
 
@@ -974,12 +1226,9 @@ textarea:focus {
 }
 
 .hands-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   display: grid;
-  gap: 0.55rem;
-  max-height: 420px;
+  gap: 0.65rem;
+  max-height: 520px;
   overflow: auto;
 }
 
@@ -989,15 +1238,25 @@ textarea:focus {
 
 .hands-list button {
   width: 100%;
+  padding: 1rem 1.05rem;
   text-align: left;
   color: var(--text);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(245, 239, 229, 0.9));
-  border-color: rgba(92, 72, 40, 0.12);
   box-shadow: none;
 }
 
+.hands-list button:hover:not(:disabled) {
+  transform: translateX(2px);
+  border-color: rgba(31, 109, 85, 0.2);
+}
+
+.hands-list button.is-active {
+  background: linear-gradient(180deg, rgba(231, 246, 240, 0.95), rgba(244, 250, 247, 0.92));
+  border-color: rgba(31, 109, 85, 0.22);
+}
+
 .detail-body {
-  gap: 0.85rem;
+  display: grid;
+  gap: 0.9rem;
 }
 
 .detail-tabs {
@@ -1007,24 +1266,23 @@ textarea:focus {
 }
 
 .detail-tab.active {
-  color: #fff9f0;
+  color: #fffaf3;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   border-color: transparent;
 }
 
 .hand-detail {
   margin: 0;
-  min-height: 300px;
-  max-height: 420px;
+  min-height: 360px;
+  max-height: 520px;
   overflow: auto;
-  padding: 1rem;
-  border-radius: 24px;
-  background: linear-gradient(180deg, #13261e, #0f1d17);
-  color: #d7eedf;
-  border: 1px solid rgba(233, 213, 166, 0.12);
+  padding: 1.1rem;
+  background: linear-gradient(180deg, #183025, #12241c);
+  color: #d9eee1;
+  border-color: rgba(233, 213, 166, 0.1);
   font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
   font-size: 0.9rem;
-  line-height: 1.55;
+  line-height: 1.58;
 }
 
 .seat-assignment-modal {
@@ -1033,8 +1291,8 @@ textarea:focus {
   z-index: 40;
   display: grid;
   place-items: center;
-  padding: var(--space-4);
-  background: rgba(25, 17, 8, 0.56);
+  padding: 1rem;
+  background: rgba(24, 17, 8, 0.42);
   backdrop-filter: blur(10px);
 }
 
@@ -1056,7 +1314,7 @@ textarea:focus {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-3);
+  gap: 0.8rem 1rem;
 }
 
 .seat-assignment-subtitle {
@@ -1072,162 +1330,12 @@ textarea:focus {
 
 .seat-assignment-form {
   padding: 1rem;
-  border-radius: 24px;
-  border: 1px solid rgba(92, 72, 40, 0.12);
-  background: rgba(255, 255, 255, 0.56);
   display: grid;
   gap: 0.55rem;
 }
 
 .seat-assignment-form h4 {
   font-size: 1.15rem;
-}
-
-.lobby-grid,
-.my-bots-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--space-4);
-}
-
-.create-table-form,
-.my-bots-upload-form {
-  display: grid;
-  gap: 0.55rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-#create-table-submit,
-#my-bots-upload-submit,
-.my-bots-upload-form #bot-file {
-  grid-column: 1 / -1;
-}
-
-.lobby-table-cards {
-  display: none;
-  gap: 0.8rem;
-}
-
-.lobby-table-card,
-.my-bot-card,
-.lobby-leaderboard-item {
-  border-radius: 22px;
-  border: 1px solid rgba(92, 72, 40, 0.12);
-  background: rgba(255, 255, 255, 0.58);
-  animation: card-enter 260ms ease;
-}
-
-.lobby-table-card,
-.my-bot-card {
-  padding: 1rem;
-}
-
-.lobby-table-card {
-  display: grid;
-  gap: 0.8rem;
-}
-
-.lobby-table-card-header,
-.my-bot-card-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.lobby-card-meta,
-.my-bot-meta-row,
-.lobby-leaderboard-meta {
-  color: var(--muted);
-}
-
-.lobby-card-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem 1rem;
-  color: var(--muted-strong);
-  font-weight: 700;
-}
-
-.lobby-table-scroll {
-  overflow-x: auto;
-}
-
-.lobby-tables-table {
-  width: 100%;
-  border-collapse: collapse;
-  min-width: 640px;
-}
-
-.lobby-tables-table th,
-.lobby-tables-table td {
-  padding: 0.85rem 0.65rem;
-  border-bottom: 1px solid rgba(92, 72, 40, 0.1);
-  text-align: left;
-  vertical-align: middle;
-}
-
-.lobby-tables-table th {
-  color: var(--muted);
-  font-size: 0.84rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.table-id {
-  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
-  font-size: 0.82rem;
-}
-
-.lobby-leaderboard-list,
-.my-bots-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.lobby-leaderboard-list {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.lobby-leaderboard-item {
-  padding: 0.95rem 1rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.85rem;
-}
-
-.lobby-leaderboard-rank {
-  font-weight: 800;
-}
-
-.lobby-leaderboard-stat {
-  color: var(--accent);
-  font-weight: 800;
-  white-space: nowrap;
-}
-
-.my-bots-list {
-  display: grid;
-  gap: 0.9rem;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-}
-
-.my-bot-card {
-  display: grid;
-  gap: 0.45rem;
-}
-
-.my-bot-card h3 {
-  font-size: 1.2rem;
-}
-
-.bot-status-pill {
-  background: rgba(25, 98, 76, 0.12);
-  border-color: rgba(25, 98, 76, 0.18);
-  color: var(--accent-strong);
 }
 
 .toast-region {
@@ -1241,8 +1349,8 @@ textarea:focus {
 
 .toast {
   padding: 0.95rem 1rem;
-  border-radius: 20px;
-  border: 1px solid rgba(92, 72, 40, 0.12);
+  border-radius: 22px;
+  border: 1px solid var(--card-border);
   background: rgba(255, 251, 244, 0.96);
   box-shadow: var(--shadow-strong);
   display: grid;
@@ -1253,15 +1361,15 @@ textarea:focus {
 }
 
 .toast-success {
-  border-color: rgba(25, 98, 76, 0.18);
+  border-color: rgba(31, 109, 85, 0.18);
 }
 
 .toast-error {
-  border-color: rgba(175, 71, 56, 0.24);
+  border-color: rgba(179, 75, 61, 0.22);
 }
 
 .toast-warning {
-  border-color: rgba(154, 106, 32, 0.2);
+  border-color: rgba(154, 109, 40, 0.2);
 }
 
 .toast-dismiss {
@@ -1286,21 +1394,22 @@ textarea:focus {
     transform 160ms ease;
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1280px) {
+  .page-hero,
   .arena-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .page-intro {
     grid-template-columns: 1fr;
   }
 
   .page-intro-metrics {
     justify-content: flex-start;
   }
+
+  .pnl-panel {
+    position: static;
+  }
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 1080px) {
   .auth-grid,
   .lobby-grid,
   .my-bots-grid,
@@ -1314,60 +1423,55 @@ textarea:focus {
 }
 
 @media (max-width: 900px) {
-  .layout,
-  .auth-layout {
-    padding: 1rem;
+  .auth-metrics,
+  .seat-assignment-grid,
+  .create-table-form,
+  .my-bots-upload-form {
+    grid-template-columns: 1fr;
   }
 
   .poker-table {
-    min-height: 520px;
+    min-height: 560px;
   }
 
   .seat {
-    width: min(150px, 34%);
+    width: min(154px, 34%);
   }
 
   .seat-2,
   .seat-3 {
-    right: 1rem;
+    right: 1.2rem;
   }
 
   .seat-5,
   .seat-6 {
-    left: 1rem;
-  }
-
-  .seat-assignment-grid,
-  .create-table-form,
-  .my-bots-upload-form,
-  .auth-metrics {
-    grid-template-columns: 1fr;
+    left: 1.2rem;
   }
 }
 
-@media (max-width: 720px) {
-  .app-header {
-    padding: 1rem;
+@media (max-width: 760px) {
+  .layout,
+  .auth-layout {
+    width: calc(100vw - 1.25rem);
   }
 
-  .page-intro,
-  .table-area,
-  .match-controls,
-  .pnl-panel,
-  .history-panel,
-  .lobby-panel,
-  .my-bots-panel {
-    padding: 1rem;
+  .shell-strip {
+    padding-bottom: 1rem;
+  }
+
+  .page-hero {
+    padding-bottom: 1rem;
   }
 
   .poker-table {
     min-height: auto;
     aspect-ratio: auto;
     padding: 1rem;
-    border-radius: 32px;
+    border-radius: 34px;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.85rem;
+    animation: none;
   }
 
   .poker-table::before,
@@ -1381,7 +1485,6 @@ textarea:focus {
     transform: none;
     width: 100%;
     grid-column: 1 / -1;
-    animation: none;
   }
 
   .seat {
@@ -1398,7 +1501,7 @@ textarea:focus {
   .hands-controls,
   .detail-tabs {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .match-buttons > *,
@@ -1421,50 +1524,17 @@ textarea:focus {
 }
 
 @media (max-width: 560px) {
+  .layout,
   .auth-layout {
-    padding: 0.75rem;
+    width: calc(100vw - 0.9rem);
   }
 
-  .auth-card,
-  .auth-hero,
-  .page-intro,
-  .lobby-panel,
-  .my-bots-panel,
-  .table-area,
-  .match-controls,
-  .pnl-panel,
-  .history-panel {
-    border-radius: 22px;
-  }
-
-  .poker-table {
-    grid-template-columns: 1fr;
-  }
-
-  .match-buttons,
-  .hands-controls,
-  .detail-tabs,
-  .app-nav {
-    grid-template-columns: 1fr;
-  }
-
+  .app-nav,
   .match-buttons,
   .hands-controls,
   .detail-tabs {
     display: grid;
-  }
-
-  .page-intro-metrics {
-    align-items: stretch;
-  }
-
-  .metric-pill,
-  .table-state-pill,
-  .bot-status-pill,
-  .seat-status,
-  .page-intro-metrics > * {
-    width: 100%;
-    justify-content: center;
+    grid-template-columns: 1fr;
   }
 
   .app-nav {
@@ -1477,16 +1547,46 @@ textarea:focus {
     justify-content: center;
   }
 
+  .page-intro-metrics,
+  .lobby-card-stats {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .metric-pill,
+  .table-state-pill,
+  .bot-status-pill,
+  .seat-status,
+  .page-intro-metrics > * {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .poker-table,
+  .auth-metrics {
+    grid-template-columns: 1fr;
+  }
+
   .lobby-leaderboard-item,
   .my-bot-card-header,
   .lobby-table-card-header,
   .panel-header,
   .seat-assignment-header {
-    flex-direction: column;
-    align-items: flex-start;
+    grid-template-columns: 1fr;
+    display: grid;
+    align-items: start;
   }
 
-  .lobby-leaderboard-stat {
+  .lobby-leaderboard-item {
+    grid-template-columns: 1fr;
+  }
+
+  .leaderboard-item {
+    grid-template-columns: 1fr;
+  }
+
+  .lobby-leaderboard-stat,
+  .leaderboard-stat {
     white-space: normal;
   }
 }

--- a/frontend/table-detail.html
+++ b/frontend/table-detail.html
@@ -8,11 +8,11 @@
   </head>
   <body data-page="table-detail">
     <main id="app-shell" class="layout shell-page" aria-live="polite">
-      <header class="app-header surface-panel">
+      <header class="app-header shell-strip">
         <div class="app-brand">
           <p class="panel-eyebrow">Poker Bots Playground</p>
-          <h1>Table Detail</h1>
-          <p>Seat bots, run matches, and review hand history without leaving the live arena.</p>
+          <h1>Table</h1>
+          <p>Seat bots, run the match, and inspect history from one live workspace.</p>
         </div>
         <nav class="app-nav" aria-label="Primary">
           <a id="nav-lobby" data-nav="lobby" href="/lobby">Lobby</a>
@@ -21,12 +21,12 @@
         </nav>
       </header>
 
-      <section class="page-intro surface-panel page-intro-table">
+      <section class="page-intro page-hero page-intro-table">
         <div>
           <p class="panel-eyebrow">Live Arena</p>
-          <h2>Run a responsive 6-max table from one screen.</h2>
+          <h2>Keep the live table readable while everything updates.</h2>
           <p class="page-intro-copy">
-            Desktop keeps the felt-focused layout; smaller screens switch to readable stacked seat cards and compact control groups.
+            The table stays central on larger screens, while mobile collapses into a clear stacked flow instead of forcing tiny panels and cramped controls.
           </p>
         </div>
         <div class="page-intro-metrics">
@@ -39,18 +39,18 @@
 
       <section class="arena-layout">
         <div class="arena-stage">
-          <section class="table-area surface-panel">
+          <section class="table-area section-shell">
             <div class="panel-header panel-header-tight">
               <div>
                 <p class="panel-eyebrow">Arena</p>
-                <h2>Premium table view</h2>
+                <h2>Live table</h2>
               </div>
             </div>
 
             <div class="poker-table" data-testid="poker-table">
               <div class="table-center">
-                <p class="table-center-eyebrow">Premium Arena</p>
-                <h2 class="table-center-title">6-Max NLH Arena</h2>
+                <p class="table-center-eyebrow">Live Table</p>
+                <h2 class="table-center-title">6-Max NLH</h2>
                 <div class="table-center-meta">
                   <span id="table-center-status">Waiting</span>
                   <span id="table-center-hands">0 hands played</span>
@@ -125,11 +125,11 @@
             </div>
           </section>
 
-          <section class="match-controls surface-panel">
+          <section class="match-controls section-shell">
             <div class="panel-header">
               <div>
                 <p class="panel-eyebrow">Match Controls</p>
-                <h2>Control live play</h2>
+                <h2>Run the match</h2>
               </div>
             </div>
             <div class="match-buttons">
@@ -146,7 +146,7 @@
           </section>
         </div>
 
-        <aside class="pnl-panel surface-panel">
+        <aside class="pnl-panel section-shell">
           <div class="panel-header">
             <div>
               <p class="panel-eyebrow">Standings</p>
@@ -171,11 +171,11 @@
       </section>
 
       <section class="history-grid">
-        <section class="history-panel surface-panel">
+        <section class="history-panel section-shell">
           <div class="panel-header">
             <div>
               <p class="panel-eyebrow">Timeline</p>
-              <h2>Hands Played</h2>
+              <h2>Recent Hands</h2>
             </div>
             <button id="hand-history-button" type="button" data-testid="hand-history-button">Hand History</button>
           </div>
@@ -199,7 +199,7 @@
           </div>
         </section>
 
-        <section class="history-panel surface-panel">
+        <section class="history-panel section-shell">
           <div class="panel-header">
             <div>
               <p class="panel-eyebrow">Detail</p>

--- a/frontend/table-detail.js
+++ b/frontend/table-detail.js
@@ -22,6 +22,7 @@
   let pnlVisibility = {};
   let activeSeatId = null;
   let myBotsCache = [];
+  let currentHands = [];
   let seatAssignmentBusy = false;
   let stateRefreshInFlight = false;
   let refreshErrorNotified = false;
@@ -627,6 +628,7 @@
     if (!list) {
       return;
     }
+    currentHands = hands.slice();
     list.innerHTML = "";
 
     if (!hands.length) {
@@ -642,6 +644,7 @@
       const button = document.createElement("button");
       button.type = "button";
       button.textContent = hand.summary;
+      button.classList.toggle("is-active", hand.hand_id === selectedHandId);
       button.addEventListener("click", () => openHand(hand.hand_id));
       item.appendChild(button);
       list.appendChild(item);
@@ -714,6 +717,9 @@
     const hand = await window.AppShell.request(tableApiPath(`/hands/${encodeURIComponent(handId)}`));
     selectedHandId = handId;
     handDetailText = hand.history || "No hand history available.";
+    if (currentHands.length) {
+      renderHands(currentHands);
+    }
     setHandDetailMode("logs");
   }
 
@@ -729,6 +735,7 @@
     handsPage = 1;
     handsTotalHands = 0;
     handsTotalPages = 0;
+    currentHands = [];
     currentHandsSignature = "";
     const list = document.getElementById("hands-list");
     if (list) {


### PR DESCRIPTION
## Summary
- simplify the shared frontend shell so login, lobby, my bots, and table pages feel lighter and less boxed in
- refresh spacing, typography, cards, and responsive behavior with a cleaner full-width visual system
- keep live table behavior intact while improving hand-list affordances and mobile usability

## Verification
- /home/mmestrov/Desktop/projects/poker-bots-playground/backend/.venv/bin/pytest backend/tests/test_frontend_auth_shell.py -q
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:8011 npm run test:e2e -- --project=chromium-desktop --project=chromium-mobile

## Notes
- the marin worktree base for this task does not include TASKS.md, so there was no branch-local task file to update